### PR TITLE
feat: type and scope are case insensitive

### DIFF
--- a/commit-msg
+++ b/commit-msg
@@ -67,14 +67,16 @@ while read -r line; do
   # Linewise requirements
   case ${line_number} in
     0)
-      if ! [[ ${line} =~ ^((build|chore|ci|docs|feat|fix|perf|refactor|style|test|wip)(\([a-zA-Z0-9]+\))?(!)?: [^ ]+.*$) ]]; then
-        if [ "${line:0:7}" = "fixup! " ]; then
+      downcase_line=$(echo "$line" | tr '[:upper:]' '[:lower:]')
+
+      if ! [[ ${downcase_line} =~ ^((build|chore|ci|docs|feat|fix|perf|refactor|style|test|wip)(\([a-zA-Z0-9]+\))?(!)?: [^ ]+.*$) ]]; then
+        if [ "${downcase_line:0:7}" = "fixup! " ]; then
           echo -e "${yellow}Conventional commit message check skipped on fixup commits.${NC}"
           break;
-        elif [[ "${line:0:6}" = "Merge " ]]; then
+        elif [[ "${downcase_line:0:6}" = "merge " ]]; then
           echo -e "${yellow}Conventional commit first-line check skipped on merge commits.${NC}"
           continue;
-        elif [[ "${line:0:7}" = "Revert " ]] || [[ "${line:0:7}" = "revert " ]]; then
+        elif [[ "${downcase_line:0:7}" = "revert " ]]; then
           echo -e "${yellow}Conventional commit first-line check skipped on revert commits.${NC}"
           continue;
         fi

--- a/test/commit-msg.bats
+++ b/test/commit-msg.bats
@@ -42,9 +42,29 @@ setup() {
   assert_output --partial "${SUCCESS_MESSAGE_SNIPPET}"
 }
 
+@test "passes compliant one-liner with mixed cased type" {
+  FILE="${BATS_TMPDIR}/${BATS_TEST_NUMBER}"
+  echo "fEaT: a compliant one-liner" > "${FILE}"
+
+  run ./commit-msg "${FILE}"
+
+  assert_success
+  assert_output --partial "${SUCCESS_MESSAGE_SNIPPET}"
+}
+
 @test "passes compliant one-liner with scope" {
   FILE="${BATS_TMPDIR}/${BATS_TEST_NUMBER}"
   echo "feat(location): a compliant one-liner" > "${FILE}"
+
+  run ./commit-msg "${FILE}"
+
+  assert_success
+  assert_output --partial "${SUCCESS_MESSAGE_SNIPPET}"
+}
+
+@test "passes compliant one-liner with mixed casescope" {
+  FILE="${BATS_TMPDIR}/${BATS_TEST_NUMBER}"
+  echo "feat(lOcAtIoN): a compliant one-liner" > "${FILE}"
 
   run ./commit-msg "${FILE}"
 
@@ -215,9 +235,21 @@ setup() {
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Simple cases (skips):
-@test "ignores single-line merge commits" {
+@test "ignores single-line merge commits (titlecase)" {
   FILE="${BATS_TMPDIR}/${BATS_TEST_NUMBER}"
   echo "Merge pull request #123" > "${FILE}"
+
+  run ./commit-msg "${FILE}"
+
+  assert_equal "${status}" 0
+  assert_success
+  assert_output --partial "skipped on merge commits"
+  assert_output --partial "${SUCCESS_MESSAGE_SNIPPET}"
+}
+
+@test "ignores single-line merge commits (lowercase)" {
+  FILE="${BATS_TMPDIR}/${BATS_TEST_NUMBER}"
+  echo "merge pull request #123" > "${FILE}"
 
   run ./commit-msg "${FILE}"
 


### PR DESCRIPTION
Fixes #13

Per [the spec](https://www.conventionalcommits.org/en/v1.0.0/#specification):

> The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.